### PR TITLE
Add markup to post content

### DIFF
--- a/petpals/forum/post/templates/post.html
+++ b/petpals/forum/post/templates/post.html
@@ -34,7 +34,7 @@
               <h5 class="mt-1">{{ post.title }}</h5>
               <div class="mt-3 font-size-sm">
                 {% if post.content %}
-                {% for line in post.content.splitlines() %}
+                {% for line in content_markup(post.content).splitlines() %}
                   <p class="mb-0">{{ line }}</p>
                 {% endfor %}
               {% endif %}

--- a/petpals/forum/routes.py
+++ b/petpals/forum/routes.py
@@ -2,6 +2,8 @@ from flask import Blueprint, render_template, request
 from petpals.models import Post, db
 from sqlalchemy import or_
 
+from .utils import utility_processor
+
 router = Blueprint(
     'forum_router', __name__, template_folder='templates', url_prefix='/forum'
 )
@@ -27,3 +29,6 @@ def search():
         .all()
     )
     return render_template('forum.html', posts=posts)
+
+
+router.context_processor(utility_processor)

--- a/petpals/forum/templates/forum.html
+++ b/petpals/forum/templates/forum.html
@@ -96,7 +96,7 @@ active_page = 'forum' %} {% block body %}
                       </h6>
 
                       {% if post.content %}
-                      {% for line in post.content.splitlines() %}
+                      {% for line in content_markup(post.content).splitlines() %}
                       <p class="text-secondary">{{ line }}</p>
                       {% endfor %}
                       {% endif %}

--- a/petpals/forum/utils.py
+++ b/petpals/forum/utils.py
@@ -5,7 +5,13 @@ from markupsafe import Markup
 
 
 def replace_markup(match: re.Match) -> str:
-    url = url_for("profile_router.profile_user", username=match[1])
+    if match['pet']:
+        url = url_for(
+            'profile_router.profile_pet', username=match['user'], pet_name=match['pet']
+        )
+    else:
+        url = url_for("profile_router.profile_user", username=match['user'])
+
     return f'<a href="{url}">{match[0]}</a>'
 
 
@@ -13,6 +19,12 @@ def utility_processor():
     def content_markup(content: str) -> Markup:
         safe_content = Markup.escape(content)
 
-        return Markup(re.sub(r'@([\w-]+)', replace_markup, safe_content))
+        return Markup(
+            re.sub(
+                r'@(?P<user>[\w-]+)(?:\[(?P<pet>[\w -]+)\])?',
+                replace_markup,
+                safe_content,
+            )
+        )
 
     return dict(content_markup=content_markup)

--- a/petpals/forum/utils.py
+++ b/petpals/forum/utils.py
@@ -1,0 +1,18 @@
+import re
+
+from flask import url_for
+from markupsafe import Markup
+
+
+def replace_markup(match: re.Match) -> str:
+    url = url_for("profile_router.profile_user", username=match[1])
+    return f'<a href="{url}">{match[0]}</a>'
+
+
+def utility_processor():
+    def content_markup(content: str) -> Markup:
+        safe_content = Markup.escape(content)
+
+        return Markup(re.sub(r'@([\w-]+)', replace_markup, safe_content))
+
+    return dict(content_markup=content_markup)

--- a/petpals/forum/utils.py
+++ b/petpals/forum/utils.py
@@ -21,7 +21,7 @@ def utility_processor():
 
         return Markup(
             re.sub(
-                r'@(?P<user>[\w-]+)(?:\[(?P<pet>[\w -]+)\])?',
+                r'(?<![\w-])@(?P<user>[\w-]+)(?:\[(?P<pet>[\w -]+)\])?',
                 replace_markup,
                 safe_content,
             )

--- a/petpals/forum/utils.py
+++ b/petpals/forum/utils.py
@@ -21,7 +21,7 @@ def utility_processor():
 
         return Markup(
             re.sub(
-                r'(?<![\w-])@(?P<user>[\w-]+)(?:\[(?P<pet>[\w -]+)\])?',
+                r'(?:(?<=\s)|(?<=^))@(?P<user>[\w-]+)(?:\[(?P<pet>[\w -]+)\])?',
                 replace_markup,
                 safe_content,
             )


### PR DESCRIPTION
- `@username` hyperlinks a user
- `@username[petname]` hyperlinks a pet
- Must not have a character, other than whitespace, behind it
- Markup will always hyper link regardless of whether user/pet exists or not.
  - It was easier and lets user know they used the markup if it was accidental.